### PR TITLE
Add .gitignore for video-review-cli and update Windows build instructions

### DIFF
--- a/maintenance/.gitignore
+++ b/maintenance/.gitignore
@@ -1,0 +1,1 @@
+video-review-cli*

--- a/maintenance/README.jp.md
+++ b/maintenance/README.jp.md
@@ -6,7 +6,7 @@ VideoReview のメンテナンス用 CLI ツールです
 ## ビルド方法
 
 ### Windows
-> GOOS=windows GOARCH=amd64 go build -o video-review-cli
+> $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o video-review-cli.exe
 
 ### Mac
 > GOOS=darwin GOARCH=arm64 go build -o video-review-cli

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -6,7 +6,7 @@ It is an **internal administrator tool** separate from the main application.
 ## Build Instructions
 
 ### Windows
-> GOOS=windows GOARCH=amd64 go build -o video-review-cli
+> $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o video-review-cli.exe
 
 ### Mac
 > GOOS=darwin GOARCH=arm64 go build -o video-review-cli


### PR DESCRIPTION
Include a .gitignore file for the video-review-cli and modify the README to provide updated build instructions for Windows, ensuring the executable file has the correct extension.