### PR TITLE
Filter out deleted video revisions in list response

### DIFF
--- a/src/server/routes/videos/list.ts
+++ b/src/server/routes/videos/list.ts
@@ -112,6 +112,7 @@ listRouter.openapi({
             ...(includeRevisions ? {
                 include: {
                 revisions: {
+                    where: { deleted: false },
                     orderBy: { revision: "asc" },
                 },
             },


### PR DESCRIPTION
Ensure that the response for video revisions excludes any that have been marked as deleted.