### PR TITLE
Deprecate maintenance tokens and set API tokens as primary authentication

### DIFF
--- a/.aws/amplify.build.yml
+++ b/.aws/amplify.build.yml
@@ -11,7 +11,6 @@ frontend:
         - echo "S3_REGION=$S3_REGION" >> .env
         - echo "VIDEO_REVIEW_STORAGE=$VIDEO_REVIEW_STORAGE" >> .env
         - echo "VIDEO_REVIEW_API_TOKEN=$VIDEO_REVIEW_API_TOKEN" >> .env
-        - echo "ADMIN_MAINTENANCE_TOKEN=$ADMIN_MAINTENANCE_TOKEN" >> .env
         - echo "DATABASE_URL=$DATABASE_URL" >> .env
         - npm run build
   artifacts:

--- a/.example.env
+++ b/.example.env
@@ -50,7 +50,7 @@ VIDEO_REVIEW_API_TOKEN=""
 
 
 # ---------------------------------------------------------------------
-#  VideoReview Maintenance Token
+#  VideoReview Maintenance Token (deprecated)
 # ---------------------------------------------------------------------
 ADMIN_MAINTENANCE_TOKEN=""
 

--- a/maintenance/README.jp.md
+++ b/maintenance/README.jp.md
@@ -19,9 +19,9 @@ VideoReview のメンテナンス用 CLI ツールです
 VideoReviewを動作させているサーバーURL
 > VIDEO_REVIEW_SERVER_URL
 
-メンテナンス用トークン  
+VideoReview API トークン  
 .env と同じものを設定してください
-> ADMIN_MAINTENANCE_TOKEN
+> VIDEO_REVIEW_API_TOKEN
 
 
 ### コマンド一覧
@@ -43,3 +43,6 @@ VideoReviewを動作させているサーバーURL
 * ファイル削除＋論理削除を行います
 * 実行後に元に戻すことはできません
 > go run .  purge-revision --video_id {uuid} --revision 1
+
+##### 動画をアップロードします
+> go run . upload-video --title "title" --folder_key "folder_key" --scene_path "scene_path" --video_path "/path/to/video.mp4"

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -19,9 +19,9 @@ It is an **internal administrator tool** separate from the main application.
 URL of the server running VideoReview
 > VIDEO_REVIEW_SERVER_URL
 
-Maintenance Token  
+VideoReview API Token  
 Set the same value as in .env
-> ADMIN_MAINTENANCE_TOKEN
+> VIDEO_REVIEW_API_TOKEN
 
 ### Command List
 
@@ -42,3 +42,6 @@ Set the same value as in .env
 * Performs file deletion + logical deletion
 * Cannot be undone after execution
 > go run . purge-revision --video_id {uuid} --revision 1
+
+##### Upload a video
+> go run . upload-video --title "title" --folder_key "folder_key" --scene_path "scene_path" --video_path "/path/to/video.mp4"

--- a/maintenance/internal/commands/create-admin.go
+++ b/maintenance/internal/commands/create-admin.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunCreateAdmin(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	email := fs.String("email", "", "admin email")
+	pass := fs.String("pass", "", "admin password")
+	fs.Parse(args)
+
+	if *email == "" || *pass == "" {
+		fmt.Println("email and pass are required")
+		fs.Usage()
+		return
+	}
+
+	Fetch(FetchOptions{
+		Method: POST,
+		Path:   "/api/v1/admin/user",
+		Json: map[string]any{
+			"email": email,
+			"pass":  pass,
+		},
+	})
+}

--- a/maintenance/internal/commands/delete-video.go
+++ b/maintenance/internal/commands/delete-video.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunDeleteVideo(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	videoId := fs.String("video_id", "", "video id")
+	fs.Parse(args)
+
+	if *videoId == "" {
+		fmt.Println("videoId is required")
+		fs.Usage()
+		return
+	}
+
+	Fetch(FetchOptions{
+		Method: POST,
+		Path:   "/api/v1/admin/maintenance/video/delete",
+		Json: map[string]any{
+			"videoId": *videoId,
+			"deleted": "true",
+		},
+	})
+}

--- a/maintenance/internal/commands/get-videos-rev.go
+++ b/maintenance/internal/commands/get-videos-rev.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunGetVideosRev(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	videoId := fs.String("video_id", "", "video id")
+	fs.Parse(args)
+
+	if *videoId == "" {
+		fmt.Println("videoId is required")
+		fs.Usage()
+		return
+	}
+
+	Fetch(FetchOptions{
+		Method: GET,
+		Path:   fmt.Sprintf("/api/v1/videos/%s/revisions", *videoId),
+	})
+}

--- a/maintenance/internal/commands/get-videos.go
+++ b/maintenance/internal/commands/get-videos.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"flag"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunGetVideos(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	includeRevisions := fs.String("include_revisions", "false", "include revisions")
+	fs.Parse(args)
+
+	Fetch(FetchOptions{
+		Method: GET,
+		Path:   "/api/v1/videos",
+		Query: map[string]string{
+			"includeRevisions": *includeRevisions,
+		},
+	})
+}

--- a/maintenance/internal/commands/purge-revision.go
+++ b/maintenance/internal/commands/purge-revision.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunPurgeRevision(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	videoId := fs.String("video_id", "", "video id")
+	revision := fs.Int("revision", -1, "revision number")
+	fs.Parse(args)
+
+	if *videoId == "" || *revision == -1 {
+		fmt.Println("videoId and revision are required")
+		fs.Usage()
+		return
+	}
+
+	Fetch(FetchOptions{
+		Method: POST,
+		Path:   "/api/v1/admin/maintenance/video/purge",
+		Json: map[string]any{
+			"videoId":  *videoId,
+			"revision": fmt.Sprintf("%d", *revision),
+		},
+	})
+}

--- a/maintenance/internal/commands/upload-video.go
+++ b/maintenance/internal/commands/upload-video.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	. "videoreview-maintenance/internal/lib"
+)
+
+func RunUploadVideo(cmd string, args []string) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	title := fs.String("title", "", "title of the video")
+	folderKey := fs.String("folder_key", "", "folder key for the video")
+	scenePath := fs.String("scene_path", "", "scene path of the video")
+	videoPath := fs.String("video_path", "", "path to the video file")
+	fs.Parse(args)
+
+	if *title == "" || *folderKey == "" {
+		fmt.Println("title, folder_key and scene_path are required")
+		fs.Usage()
+		return
+	}
+
+	if *videoPath == "" {
+		fmt.Println("video_path is required")
+		fs.Usage()
+		return
+	}
+
+	if _, err := os.Stat(*videoPath); err != nil {
+		fmt.Println("video file does not exist or cannot be accessed:", err)
+		return
+	}
+
+	var session UploadSessionWithURL
+	{
+		b, err := FetchRaw(FetchOptions{
+			Method: POST,
+			Path:   "/api/v1/videos/upload/init",
+			Form: map[string]string{
+				"folderKey": *folderKey,
+				"title":     *title,
+				"scenePath": *scenePath,
+			},
+		})
+		if err != nil {
+			fmt.Println("failed to fetch upload session:", err)
+			return
+		}
+		if err := json.Unmarshal(b, &session); err != nil {
+			fmt.Println("failed to unmarshal upload session:", err)
+			return
+		}
+	}
+
+	file, err := os.Open(*videoPath)
+	if err != nil {
+		fmt.Println("failed to open video file:", err)
+		return
+	}
+	defer file.Close()
+
+	if session.Session.Storage == "s3" {
+		// S3 upload
+		req, err := http.NewRequest("PUT", session.URL, file)
+		if err != nil {
+			fmt.Println("failed to create request for S3 upload:", err)
+			return
+		}
+		req.Header.Set("Content-Type", "video/mp4")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			fmt.Println("failed to upload to S3:", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			b, _ := io.ReadAll(resp.Body)
+			fmt.Printf("failed to upload to S3: status %d: %s\n", resp.StatusCode, string(b))
+			return
+		}
+	} else {
+		// local or nextCloud upload
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		part, err := writer.CreateFormFile("file", filepath.Base(*videoPath))
+		if err != nil {
+			fmt.Println("failed to create multipart file:", err)
+			return
+		}
+		_, err = io.Copy(part, file)
+		if err != nil {
+			fmt.Println("failed to write file to multipart:", err)
+			return
+		}
+		writer.Close()
+
+		req, err := http.NewRequest("PUT", GlobalConfig.BaseURL+session.URL, body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		req.Header.Set("x-api-token", GlobalConfig.APIToken)
+
+		if err != nil {
+			fmt.Println("failed to create request for upload:", err)
+			return
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			fmt.Println("failed to upload video:", err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			b, _ := io.ReadAll(resp.Body)
+			fmt.Printf("failed to upload video: status %d: %s\n", resp.StatusCode, string(b))
+			return
+		}
+	}
+
+	for {
+		status, err := uploadStatus(session.Session.ID)
+		if err != nil {
+			fmt.Println("failed to get upload status:", err)
+			return
+		}
+		if status.Status == "uploaded" {
+			break
+		} else if status.Status == "failed" {
+			fmt.Println("Upload failed.")
+			break
+		}
+	}
+
+	Fetch(FetchOptions{
+		Method: POST,
+		Path:   "/api/v1/videos/upload/finish",
+		Query: map[string]string{
+			"session_id": session.Session.ID,
+		},
+	})
+}
+
+func uploadStatus(sessionID string) (UploadStatus, error) {
+	var status UploadStatus
+	b, err := FetchRaw(FetchOptions{
+		Method: GET,
+		Path:   "/api/v1/upload-status",
+		Query: map[string]string{
+			"session_id": sessionID,
+		},
+	})
+	if err != nil {
+		return status, err
+	}
+	if err := json.Unmarshal(b, &status); err != nil {
+		return status, err
+	}
+	return status, nil
+}

--- a/maintenance/internal/lib/config.go
+++ b/maintenance/internal/lib/config.go
@@ -1,0 +1,8 @@
+package lib
+
+type Config struct {
+	BaseURL  string
+	APIToken string
+}
+
+var GlobalConfig Config

--- a/maintenance/internal/lib/fetch.go
+++ b/maintenance/internal/lib/fetch.go
@@ -1,0 +1,107 @@
+package lib
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+func buildRequest(opt FetchOptions) (*http.Request, error) {
+	restURL := GlobalConfig.BaseURL + opt.Path
+
+	if len(opt.Query) > 0 {
+		q := url.Values{}
+		for k, v := range opt.Query {
+			q.Set(k, v)
+		}
+		restURL += "?" + q.Encode()
+	}
+
+	var body io.Reader
+
+	if opt.Json != nil {
+		b, err := json.Marshal(opt.Json)
+		if err != nil {
+			fmt.Println("failed:", err)
+			return nil, err
+		}
+		body = bytes.NewReader(b)
+	} else if opt.Form != nil {
+		v := url.Values{}
+		for k, v2 := range opt.Form {
+			v.Set(k, v2)
+		}
+		body = strings.NewReader(v.Encode())
+	}
+
+	req, err := http.NewRequest(string(opt.Method), restURL, body)
+	if err != nil {
+		fmt.Println("failed:", err)
+		return nil, err
+	}
+
+	// NOTE: temporary compatibility for migration.
+	// Send the same token as both x-api-token and x-maintenance-token.
+	// This will be removed once ADMIN_MAINTENANCE_TOKEN is fully deprecated.
+	req.Header.Set("x-api-token", GlobalConfig.APIToken)
+	req.Header.Set("x-maintenance-token", GlobalConfig.APIToken)
+	if opt.Json != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if opt.Form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	return req, nil
+}
+
+func doRequest(req *http.Request) ([]byte, *http.Response, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, resp, fmt.Errorf("status %d: %s", resp.StatusCode, string(b))
+	}
+
+	return b, resp, nil
+}
+
+func Fetch(opt FetchOptions) {
+	req, err := buildRequest(opt)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	body, _, err := doRequest(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	os.Stdout.Write(body)
+}
+
+func FetchRaw(opt FetchOptions) ([]byte, error) {
+	req, err := buildRequest(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	body, _, err := doRequest(req)
+	return body, err
+}

--- a/maintenance/internal/lib/types.go
+++ b/maintenance/internal/lib/types.go
@@ -1,0 +1,38 @@
+package lib
+
+import "time"
+
+type HTTPMethod string
+
+const (
+	GET  HTTPMethod = "GET"
+	POST HTTPMethod = "POST"
+	PUT  HTTPMethod = "PUT"
+)
+
+type FetchOptions struct {
+	Method HTTPMethod
+	Path   string
+	Query  map[string]string
+	Json   any
+	Form   map[string]string
+}
+
+type UploadSessionWithURL struct {
+	URL     string `json:"url"`
+	Session struct {
+		ID         string    `json:"id"`
+		StorageKey string    `json:"storageKey"`
+		Storage    string    `json:"storage"`
+		Title      string    `json:"title"`
+		FolderKey  string    `json:"folderKey"`
+		ScenePath  string    `json:"scenePath"`
+		NextRev    int       `json:"nextRev"`
+		CreatedAt  time.Time `json:"createdAt"`
+	} `json:"session"`
+}
+
+type UploadStatus struct {
+	Status     string `json:"status"`
+	RevisionId string `json:"revisionId"`
+}

--- a/maintenance/main.go
+++ b/maintenance/main.go
@@ -1,72 +1,62 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"flag"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
+
+	. "videoreview-maintenance/internal/commands"
+	. "videoreview-maintenance/internal/lib"
 )
-
-type HTTPMethod string
-
-const (
-	GET  HTTPMethod = "GET"
-	POST HTTPMethod = "POST"
-	PUT  HTTPMethod = "PUT"
-)
-
-type FetchOptions struct {
-	Method HTTPMethod
-	Path   string
-	Query  map[string]string
-	Json   any
-	Form   map[string]string
-}
 
 type Command struct {
 	Run  func(cmd string, args []string)
 	Desc string
 }
 
-var (
-	BASE_URL = os.Getenv("VIDEO_REVIEW_SERVER_URL")
-	TOKEN    = os.Getenv("ADMIN_MAINTENANCE_TOKEN")
-)
-
 var commands = map[string]Command{
 	"create-admin": {
-		Run:  runCreateAdmin,
+		Run:  RunCreateAdmin,
 		Desc: "Create admin user",
 	},
 	"get-videos": {
-		Run:  runGetVideos,
+		Run:  RunGetVideos,
 		Desc: "List videos",
 	},
 	"get-videos-rev": {
-		Run:  runGetVideosRev,
+		Run:  RunGetVideosRev,
 		Desc: "List video revisions",
 	},
 	"delete-video": {
-		Run:  runDeleteVideo,
+		Run:  RunDeleteVideo,
 		Desc: "Soft delete video",
 	},
 	"purge-revision": {
-		Run:  runPurgeRevision,
+		Run:  RunPurgeRevision,
 		Desc: "Purge video revision",
+	},
+	"upload-video": {
+		Run:  RunUploadVideo,
+		Desc: "upload video",
 	},
 }
 
 func main() {
-	if BASE_URL == "" {
+	apiToken := os.Getenv("VIDEO_REVIEW_API_TOKEN")
+	if apiToken == "" {
+		apiToken = os.Getenv("ADMIN_MAINTENANCE_TOKEN")
+	}
+
+	GlobalConfig = Config{
+		BaseURL:  os.Getenv("VIDEO_REVIEW_SERVER_URL"),
+		APIToken: apiToken,
+	}
+
+	if GlobalConfig.BaseURL == "" {
 		panic("VIDEO_REVIEW_SERVER_URL is not set")
 	}
-	if TOKEN == "" {
-		panic("ADMIN_MAINTENANCE_TOKEN is not set")
+	if GlobalConfig.APIToken == "" {
+		panic("VIDEO_REVIEW_API_TOKEN is not set")
 	}
 
 	if len(os.Args) < 2 {
@@ -74,8 +64,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	BASE_URL = strings.TrimRight(BASE_URL, "/")
-
+	GlobalConfig.BaseURL = strings.TrimRight(GlobalConfig.BaseURL, "/")
 	cmd := os.Args[1]
 	c, ok := commands[cmd]
 	if !ok {
@@ -85,159 +74,6 @@ func main() {
 	}
 
 	c.Run(cmd, os.Args[2:])
-}
-
-func runCreateAdmin(cmd string, args []string) {
-	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
-	email := fs.String("email", "", "admin email")
-	pass := fs.String("pass", "", "admin password")
-	fs.Parse(args)
-
-	if *email == "" || *pass == "" {
-		fmt.Println("email and pass are required")
-		fs.Usage()
-		return
-	}
-
-	fetch(FetchOptions{
-		Method: POST,
-		Path:   "/api/v1/admin/user",
-		Json: map[string]any{
-			"email": email,
-			"pass":  pass,
-		},
-	})
-}
-
-func runGetVideos(cmd string, args []string) {
-	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
-	includeRevisions := fs.String("include_revisions", "false", "include revisions")
-	fs.Parse(args)
-
-	fetch(FetchOptions{
-		Method: "GET",
-		Path:   "/api/v1/videos",
-		Query: map[string]string{
-			"includeRevisions": *includeRevisions,
-		},
-	})
-}
-
-func runGetVideosRev(cmd string, args []string) {
-	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
-	videoId := fs.String("video_id", "", "video id")
-	fs.Parse(args)
-
-	if *videoId == "" {
-		fmt.Println("videoId is required")
-		fs.Usage()
-		return
-	}
-
-	fetch(FetchOptions{
-		Method: GET,
-		Path:   fmt.Sprintf("/api/v1/videos/%s/revisions", *videoId),
-	})
-}
-
-func runDeleteVideo(cmd string, args []string) {
-	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
-	videoId := fs.String("video_id", "", "video id")
-	fs.Parse(args)
-
-	if *videoId == "" {
-		fmt.Println("videoId is required")
-		fs.Usage()
-		return
-	}
-
-	fetch(FetchOptions{
-		Method: POST,
-		Path:   "/api/v1/admin/maintenance/video/delete",
-		Json: map[string]any{
-			"videoId": *videoId,
-			"deleted": "true",
-		},
-	})
-}
-
-func runPurgeRevision(cmd string, args []string) {
-	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
-	videoId := fs.String("video_id", "", "video id")
-	revision := fs.Int("revision", -1, "revision number")
-	fs.Parse(args)
-
-	if *videoId == "" || *revision == -1 {
-		fmt.Println("videoId and revision are required")
-		fs.Usage()
-		return
-	}
-
-	fetch(FetchOptions{
-		Method: POST,
-		Path:   "/api/v1/admin/maintenance/video/purge",
-		Json: map[string]any{
-			"videoId":  *videoId,
-			"revision": fmt.Sprintf("%d", *revision),
-		},
-	})
-}
-
-func fetch(opt FetchOptions) {
-	restURL := BASE_URL + opt.Path
-
-	// query
-	if len(opt.Query) > 0 {
-		q := url.Values{}
-		for k, v := range opt.Query {
-			q.Set(k, v)
-		}
-		restURL += "?" + q.Encode()
-	}
-
-	var body io.Reader
-
-	if opt.Json != nil {
-		b, err := json.Marshal(opt.Json)
-		if err != nil {
-			fmt.Println("failed:", err)
-			return
-		}
-		body = bytes.NewReader(b)
-	} else if opt.Form != nil {
-		v := url.Values{}
-		for k, v2 := range opt.Form {
-			v.Set(k, v2)
-		}
-		body = strings.NewReader(v.Encode())
-	}
-
-	req, err := http.NewRequest(string(opt.Method), restURL, body)
-	if err != nil {
-		fmt.Println("failed:", err)
-		return
-	}
-
-	req.Header.Set("x-maintenance-token", TOKEN)
-	if opt.Json != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	if opt.Form != nil {
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		b, _ := io.ReadAll(resp.Body)
-		fmt.Fprintln(os.Stderr, string(b))
-		os.Exit(1)
-	}
-	io.Copy(os.Stdout, resp.Body)
 }
 
 func printUsage() {

--- a/src/server/routes/admin/index.ts
+++ b/src/server/routes/admin/index.ts
@@ -46,7 +46,20 @@ adminRouter.openapi({
         },
     },
 }, async (c) => {
-    if (c.req.header("x-maintenance-token") !== process.env.ADMIN_MAINTENANCE_TOKEN) {
+    // NOTE:
+    // x-api-token (VIDEO_REVIEW_API_TOKEN) is the primary authentication method.
+    // x-maintenance-token is kept temporarily for backward compatibility.
+
+    const apiToken = c.req.header("x-api-token");
+    const maintenanceToken = c.req.header("x-maintenance-token");
+
+    const isApiTokenValid =
+    apiToken && apiToken === process.env.VIDEO_REVIEW_API_TOKEN;
+
+    const isLegacyMaintenanceTokenValid =
+    maintenanceToken && maintenanceToken === process.env.ADMIN_MAINTENANCE_TOKEN;
+
+    if (!isApiTokenValid && !isLegacyMaintenanceTokenValid) {
         return c.json({ error: "Forbidden" }, 403);
     }
 

--- a/src/server/routes/admin/maintenance/index.ts
+++ b/src/server/routes/admin/maintenance/index.ts
@@ -39,7 +39,20 @@ maintenanceRouter.openapi({
         }
     },
 }, async (c) => {
-    if (c.req.header("x-maintenance-token") !== process.env.ADMIN_MAINTENANCE_TOKEN) {
+   // NOTE:
+    // x-api-token (VIDEO_REVIEW_API_TOKEN) is the primary authentication method.
+    // x-maintenance-token is kept temporarily for backward compatibility.
+
+    const apiToken = c.req.header("x-api-token");
+    const maintenanceToken = c.req.header("x-maintenance-token");
+
+    const isApiTokenValid =
+    apiToken && apiToken === process.env.VIDEO_REVIEW_API_TOKEN;
+
+    const isLegacyMaintenanceTokenValid =
+    maintenanceToken && maintenanceToken === process.env.ADMIN_MAINTENANCE_TOKEN;
+
+    if (!isApiTokenValid && !isLegacyMaintenanceTokenValid) {
         return c.json({ error: "Forbidden" }, 403);
     }
 
@@ -91,7 +104,20 @@ maintenanceRouter.openapi({
         }
     },
 }, async (c) => {
-    if (c.req.header("x-maintenance-token") !== process.env.ADMIN_MAINTENANCE_TOKEN) {
+   // NOTE:
+    // x-api-token (VIDEO_REVIEW_API_TOKEN) is the primary authentication method.
+    // x-maintenance-token is kept temporarily for backward compatibility.
+
+    const apiToken = c.req.header("x-api-token");
+    const maintenanceToken = c.req.header("x-maintenance-token");
+
+    const isApiTokenValid =
+    apiToken && apiToken === process.env.VIDEO_REVIEW_API_TOKEN;
+
+    const isLegacyMaintenanceTokenValid =
+    maintenanceToken && maintenanceToken === process.env.ADMIN_MAINTENANCE_TOKEN;
+
+    if (!isApiTokenValid && !isLegacyMaintenanceTokenValid) {
         return c.json({ error: "Forbidden" }, 403);
     }
 


### PR DESCRIPTION
Transition to API tokens as the main authentication method by deprecating maintenance tokens. Update related commands and routing to reflect this change.