### PR TITLE
fix(sidebar): keep desktop sidebar visible under extension-injected CSS

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -205,9 +205,12 @@ function Sidebar({
     )
   }
 
+  // Using `max-md:hidden` prevents the desktop sidebar from disappearing 
+  // when page-injected CSS from extensions like DeepL messes with our 
+  // display logic. It avoids the race condition you get with `hidden md:block`.
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className="group peer text-sidebar-foreground max-md:hidden md:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -229,7 +232,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 max-md:hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
- replace the base `hidden` + `md:block`/`md:flex` pair with `max-md:hidden` so desktop has no display:none rule competing with the responsive show
- avoids a Tailwind cascade race that DeepL (and similar extensions) can flip, which hid the video list sidebar on desktop