### PR TITLE
fix(search): drive shooting-date filter from a per-filter store

### DIFF
--- a/src/components/dialog/comment-search.tsx
+++ b/src/components/dialog/comment-search.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/ui/dialog";
 import { ControlRow } from "@/ui/control-row";
 import { useCommentSearchStore } from "@/stores/comment-search-store";
+import { useCommentSearchDateFilterStore } from "@/stores/date-filter-store";
 import { Checkbox } from "@/ui/checkbox";
 import ComboBox from "@/ui/combo-box";
 import { Button } from "@/ui/button";
@@ -22,20 +23,19 @@ export function CommentSearchDialog({ open, onClose }: { open: boolean; onClose:
     const { selectedRevision, revisions } = useVideoStore();
     const { fetchComments } = useCommentStore();
     const {
-        dateRange,
         hasDrawing,
         hasIssue,
         fetchAllComments,
         user,
         filterText,
 
-        setDateRange,
         setHasDrawing,
         setHasIssue,
         setFetchAllComments,
         setCommentUser,
         setFilterText,
     } = useCommentSearchStore();
+    const dateFilter = useCommentSearchDateFilterStore();
 
     useEffect(() => {
         void (async () => {
@@ -69,7 +69,7 @@ export function CommentSearchDialog({ open, onClose }: { open: boolean; onClose:
                                     className="border-[#ccc] w-full h-8 rounded bg-[#181818] border px-2 text-sm text-white mx-2"
                                     placeholder="Filter tree..."
                                 />
-                                <Button onClick={() => { setDateRange(undefined) }} variant="outline" className="border-[#ccc] bg-[#181818] border h-8.2">
+                                <Button onClick={() => { dateFilter.clear() }} variant="outline" className="border-[#ccc] bg-[#181818] border h-8.2">
                                     <X />
                                 </Button>
                             </div>
@@ -79,7 +79,15 @@ export function CommentSearchDialog({ open, onClose }: { open: boolean; onClose:
                     {ControlRow(t("dateRange"), () => {
                         return (
                             <div className="flex justify-between">
-                                <CalendarDateRadio value={dateRange} onSetValue={setDateRange} />
+                                <CalendarDateRadio
+                                    mode={dateFilter.mode}
+                                    range={dateFilter.mode === "range" && dateFilter.from && dateFilter.to
+                                        ? { from: new Date(dateFilter.from), to: new Date(dateFilter.to) }
+                                        : undefined}
+                                    onToday={dateFilter.setToday}
+                                    onRecent={dateFilter.setRecent}
+                                    onSetRange={dateFilter.setRange}
+                                    onClear={dateFilter.clear} />
                             </div>
                         );
                     })}

--- a/src/components/dialog/video-search.tsx
+++ b/src/components/dialog/video-search.tsx
@@ -8,6 +8,7 @@ import { ControlRow } from "@/ui/control-row";
 import ComboBox from "@/ui/combo-box";
 import { Checkbox } from "@/ui/checkbox";
 import { useVideoSearchStore } from "@/stores/video-search-store";
+import { useVideoDateFilterStore, useVideoCommentsDateFilterStore } from "@/stores/date-filter-store";
 import { Button } from "@/ui/button";
 import { useVideoStore } from "@/stores/video-store";
 import { X } from "lucide-react";
@@ -22,8 +23,6 @@ export function VideoSearchDialog({ open, onClose }: { open: boolean; onClose: (
 
     const {
         user,
-        videoDateRange,
-        commentsDateRange,
         filterIssue,
         filterTree,
         hasComment,
@@ -37,10 +36,10 @@ export function VideoSearchDialog({ open, onClose }: { open: boolean; onClose: (
         setHasIssue,
         setFilterIssue,
         setFilterTree,
-        setVideoDateRange,
-        setCommentsDateRange,
         setTags
     } = useVideoSearchStore();
+    const videoDate = useVideoDateFilterStore();
+    const commentsDate = useVideoCommentsDateFilterStore();
 
     useEffect(() => {
         void (async () => {
@@ -56,11 +55,11 @@ export function VideoSearchDialog({ open, onClose }: { open: boolean; onClose: (
 
     const handleClearUserFilter = () => {
         setCommentUser(undefined);
-        setCommentsDateRange(undefined);
+        commentsDate.clear();
     }
 
     const handleClearTreeFilter = () => {
-        setVideoDateRange(undefined);
+        videoDate.clear();
     }
 
     return (
@@ -104,7 +103,15 @@ export function VideoSearchDialog({ open, onClose }: { open: boolean; onClose: (
                                 {ControlRow(t("commentsDateRange"), () => {
                                     return (
                                         <div className="flex justify-between">
-                                            <CalendarDateRadio value={commentsDateRange} onSetValue={setCommentsDateRange} />
+                                            <CalendarDateRadio
+                                                mode={commentsDate.mode}
+                                                range={commentsDate.mode === "range" && commentsDate.from && commentsDate.to
+                                                    ? { from: new Date(commentsDate.from), to: new Date(commentsDate.to) }
+                                                    : undefined}
+                                                onToday={commentsDate.setToday}
+                                                onRecent={commentsDate.setRecent}
+                                                onSetRange={commentsDate.setRange}
+                                                onClear={commentsDate.clear} />
                                         </div>
                                     );
                                 })}
@@ -168,7 +175,15 @@ export function VideoSearchDialog({ open, onClose }: { open: boolean; onClose: (
                     {ControlRow(t("videoDateRange"), () => {
                         return (
                             <div className="flex justify-between">
-                                <CalendarDateRadio value={videoDateRange} onSetValue={setVideoDateRange} />
+                                <CalendarDateRadio
+                                    mode={videoDate.mode}
+                                    range={videoDate.mode === "range" && videoDate.from && videoDate.to
+                                        ? { from: new Date(videoDate.from), to: new Date(videoDate.to) }
+                                        : undefined}
+                                    onToday={videoDate.setToday}
+                                    onRecent={videoDate.setRecent}
+                                    onSetRange={videoDate.setRange}
+                                    onClear={videoDate.clear} />
                             </div>
                         );
                     })}

--- a/src/components/ui/calendar-date-radio.tsx
+++ b/src/components/ui/calendar-date-radio.tsx
@@ -4,19 +4,29 @@ import { Button } from '@/ui/button';
 import { ButtonGroup } from '@/ui/button-group';
 import { DateRange } from 'react-day-picker';
 import { useTranslations } from 'next-intl';
-import { toDateRange, isToday, isRecent } from '@/lib/utils/date-helper';
 import CalendarPopover from '@/ui/calendar-popover';
 import { X } from 'lucide-react';
 
+// Prop-driven and store-agnostic: the current mode drives the active highlight,
+// `range` feeds the popover calendar, and each control reports intent via a
+// callback so any date-filter store can back it.
 interface CalendarDateRadioProps extends React.ComponentProps<"div"> {
-    value: DateRange | undefined;
-    onSetValue: (x: DateRange | undefined) => void;
+    mode: "none" | "today" | "recent" | "range";
+    range: DateRange | undefined;
+    onToday: () => void;
+    onRecent: (days: number) => void;
+    onSetRange: (from: Date, to: Date) => void;
+    onClear: () => void;
     collapseCalendarBtn?: boolean;
 }
 
 export default function CalendarDateRadio({
-    value,
-    onSetValue,
+    mode,
+    range,
+    onToday,
+    onRecent,
+    onSetRange,
+    onClear,
     collapseCalendarBtn = false,
     className,
     ...props
@@ -28,36 +38,30 @@ export default function CalendarDateRadio({
         <div className={`${className}`}>
             <ButtonGroup>
                 <Button
-                    className={`text-white bg-[#333] hover:bg-[#fff] ${isToday(value) ? "bg-[#32cd32]" : ""}`}
+                    className={`text-white bg-[#333] hover:bg-[#fff] ${mode === "today" ? "bg-[#32cd32]" : ""}`}
                     variant="outline" size="sm"
-                    onClick={() => {
-                        const today = new Date();
-                        onSetValue(toDateRange(today, today));
-                    }
-                    }>
+                    onClick={onToday}>
                     {t("today")}
                 </Button>
                 <Button
-                    className={`text-white bg-[#333] hover:bg-[#fff] ${isRecent(value, recentDay) ? "bg-[#32cd32]" : ""}`}
+                    className={`text-white bg-[#333] hover:bg-[#fff] ${mode === "recent" ? "bg-[#32cd32]" : ""}`}
                     variant="outline" size="sm"
-                    onClick={() => {
-                        const today = new Date();
-                        const lastDay = new Date();
-                        lastDay.setDate(today.getDate() - recentDay);
-                        onSetValue(toDateRange(lastDay, today));
-                    }
-                    }>
+                    onClick={() => onRecent(recentDay)}>
                     {t("recent", { days: recentDay })}
                 </Button>
                 {!collapseCalendarBtn && <>
                     <CalendarPopover
                         className="border-[#ccc] bg-[#181818] border h-8.2 mx-2"
-                        value={value}
-                        onSetValue={onSetValue} />
+                        mode={mode}
+                        range={range}
+                        onToday={onToday}
+                        onRecent={onRecent}
+                        onSetRange={onSetRange}
+                        onClear={onClear} />
                 </>}
                 <Button
                     className={`text-white bg-[#333] hover:bg-[#fff]`}
-                    variant="outline" size="sm" onClick={() => { onSetValue(undefined) }}>
+                    variant="outline" size="sm" onClick={onClear}>
                     <X />
                 </Button>
             </ButtonGroup>

--- a/src/components/ui/calendar-popover.tsx
+++ b/src/components/ui/calendar-popover.tsx
@@ -2,29 +2,49 @@
 import React from 'react';
 import { Calendar as CalendarIcon, X } from 'lucide-react';
 import { Popover } from '@radix-ui/react-popover';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/ui/command';
 import { PopoverContent, PopoverTrigger } from '@/ui/popover';
 import { Button } from '@/ui/button';
-import { cn } from '@/lib/utils';
 import { DateRange } from 'react-day-picker';
 import { Calendar } from '@/ui/calendar';
 import CalendarDateRadio from '@/ui/calendar-date-radio';
 
 interface CalendarPopoverProps extends React.ComponentProps<"div"> {
-    value: DateRange | undefined;
-    onSetValue: (x: DateRange | undefined) => void;
+    mode: "none" | "today" | "recent" | "range";
+    range: DateRange | undefined;
+    onToday: () => void;
+    onRecent: (days: number) => void;
+    onSetRange: (from: Date, to: Date) => void;
+    onClear: () => void;
 }
 
 export default function CalendarPopover({
-    value,
-    onSetValue,
+    mode,
+    range,
+    onToday,
+    onRecent,
+    onSetRange,
+    onClear,
     className,
     ...props
 }: CalendarPopoverProps) {
     const [open, setOpen] = React.useState(false);
+    // Local working range so an in-progress selection (only "from" picked) stays
+    // visible until both ends are chosen, then it is committed via onSetRange.
+    const [draft, setDraft] = React.useState<DateRange | undefined>(range);
+
+    const handleOpenChange = (next: boolean) => {
+        // Re-seed the draft from the resolved range each time the popover opens.
+        if (next) setDraft(range);
+        setOpen(next);
+    };
+
+    const handleSelect = (selected: DateRange | undefined) => {
+        setDraft(selected);
+        if (selected?.from && selected?.to) onSetRange(selected.from, selected.to);
+    };
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
                 <Button className={`text-white bg-[#333] hover:bg-[#fff]`} size="sm" variant="outline">
                     <CalendarIcon />
@@ -33,16 +53,23 @@ export default function CalendarPopover({
             <PopoverContent className="flex items-center bg-[#1f1f1f] ">
                 <div>
                     <div className="flex justify-between">
-                        <CalendarDateRadio value={value} onSetValue={onSetValue} collapseCalendarBtn />
+                        <CalendarDateRadio
+                            mode={mode}
+                            range={range}
+                            onToday={onToday}
+                            onRecent={onRecent}
+                            onSetRange={onSetRange}
+                            onClear={onClear}
+                            collapseCalendarBtn />
                         <Button onClick={() => setOpen(false)} className="text-white bg-[#333] hover:bg-[#fff] hover:text-[#000]">
                             <X />
                         </Button>
                     </div>
                     <Calendar
                         mode="range"
-                        defaultMonth={value?.to}
-                        selected={value}
-                        onSelect={onSetValue}
+                        defaultMonth={draft?.to ?? range?.to}
+                        selected={draft}
+                        onSelect={handleSelect}
                         numberOfMonths={1}
                         className='rounded-md  bg-[#1f1f1f] text-white'
                         classNames={{

--- a/src/components/video-browser/header.tsx
+++ b/src/components/video-browser/header.tsx
@@ -14,6 +14,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { useVideoSearchStore } from "@/stores/video-search-store";
+import { useVideoDateFilterStore } from "@/stores/date-filter-store";
 import { useVideoStore } from "@/stores/video-store";
 import CalendarDateRadio from "@/ui/calendar-date-radio";
 import { Separator } from "../ui/separator";
@@ -23,14 +24,20 @@ export default function VideoListPanelHeader(
     const t = useTranslations("video-list-panel");
     const { role } = useAuthStore();
     const { fetchVideos } = useVideoStore();
-    const { filterTree, setFilterTree, isFiltering, clear, videoDateRange, setVideoDateRange } = useVideoSearchStore();
+    const { filterTree, setFilterTree, isFiltering, clear } = useVideoSearchStore();
+    const videoDate = useVideoDateFilterStore();
 
+    // Refetch when the tree text or the date filter changes.
     useEffect(() => {
         fetchVideos();
-    }, [filterTree, videoDateRange]);
+    }, [filterTree, videoDate.mode, videoDate.from, videoDate.to, videoDate.days]);
+
+    // The date filter now lives in its own store, so fold it into the indicator.
+    const filtering = isFiltering() || videoDate.mode !== "none";
 
     const handleClear = () => {
         clear();
+        videoDate.clear();
         fetchVideos();
     }
 
@@ -47,12 +54,12 @@ export default function VideoListPanelHeader(
                         className={`
                             inline-flex items-center justify-center
                             text-lg px-1 leading-none hover:text-[#ff5500]
-                            ${isFiltering() ? "text-[#15fa34ff]" : ""}
+                            ${filtering ? "text-[#15fa34ff]" : ""}
                         `}
                     >
                         <FontAwesomeIcon icon={faSearch} />
                     </button>
-                    {isFiltering()
+                    {filtering
                         ? (
                             <>
                                 <button
@@ -78,7 +85,16 @@ export default function VideoListPanelHeader(
             <Separator className="bg-[#333]" />
 
             <SidebarGroup className="py-0">
-                <CalendarDateRadio value={videoDateRange} onSetValue={setVideoDateRange} className="size-10" />
+                <CalendarDateRadio
+                    mode={videoDate.mode}
+                    range={videoDate.mode === "range" && videoDate.from && videoDate.to
+                        ? { from: new Date(videoDate.from), to: new Date(videoDate.to) }
+                        : undefined}
+                    onToday={videoDate.setToday}
+                    onRecent={videoDate.setRecent}
+                    onSetRange={videoDate.setRange}
+                    onClear={videoDate.clear}
+                    className="size-10" />
 
                 <SidebarGroupContent className="relative mt-1">
                     <SidebarInput

--- a/src/components/video-side-panel/panels/video-comment-panel/content.tsx
+++ b/src/components/video-side-panel/panels/video-comment-panel/content.tsx
@@ -13,6 +13,7 @@ import { RefObject, useEffect, useRef } from "react";
 import { readVideoComment } from "@/lib/fetch-wrapper";
 import CommentCard from "@/components/video-side-panel/panels/video-comment-panel/comment-card";
 import { useCommentSearchStore } from "@/stores/comment-search-store";
+import { useCommentSearchDateFilterStore } from "@/stores/date-filter-store";
 import { chatToast } from "@/components/chat-notice";
 
 export default function VideoCommentContent(props: {
@@ -23,7 +24,8 @@ export default function VideoCommentContent(props: {
     const { displayName, email, userId } = useAuthStore();
     const { selectedVideo, selectedRevision } = useVideoStore();
     const { setDisplayComments, comments, addComment, fetchComments } = useCommentStore();
-    const { dateRange, filterText } = useCommentSearchStore();
+    const { filterText } = useCommentSearchStore();
+    const dateFilter = useCommentSearchDateFilterStore();
     const { canvasSave } = useDrawingStore();
     const { videoRefElement, currentTime } = useVideoReviewStore();
     const {
@@ -117,7 +119,7 @@ export default function VideoCommentContent(props: {
         if (selectedRevision) {
             fetchComments(selectedRevision);
         }
-    }, [dateRange, filterText]);
+    }, [dateFilter.mode, dateFilter.from, dateFilter.to, dateFilter.days, filterText]);
 
     return (
         <div 

--- a/src/components/video-side-panel/panels/video-comment-panel/index.tsx
+++ b/src/components/video-side-panel/panels/video-comment-panel/index.tsx
@@ -9,6 +9,7 @@ import { X, Search } from "lucide-react";
 import { SidebarGroup, SidebarGroupContent, SidebarInput } from "@/ui/sidebar";
 import VideoCommentContent from "@/components/video-side-panel/panels/video-comment-panel/content";
 import { useCommentSearchStore } from "@/stores/comment-search-store";
+import { useCommentSearchDateFilterStore } from "@/stores/date-filter-store";
 import { useCommentStore } from "@/stores/comment-store";
 import { useVideoStore } from "@/stores/video-store";
 import { VideoSidePanelDefinition } from "@/components/video-side-panel/types";
@@ -18,6 +19,10 @@ export function useVideoCommentPanelDefinition(): VideoSidePanelDefinition {
     const { selectedRevision } = useVideoStore();
     const { fetchComments } = useCommentStore();
     const commentSearch = useCommentSearchStore();
+    const dateFilter = useCommentSearchDateFilterStore();
+
+    // The date filter lives in its own store, so fold it into the indicator.
+    const filtering = commentSearch.isFiltering() || dateFilter.mode !== "none";
 
     return {
         key: "comments",
@@ -30,16 +35,17 @@ export function useVideoCommentPanelDefinition(): VideoSidePanelDefinition {
                     className={`
                         inline-flex items-center justify-center
                         text-lg px-1 leading-none hover:text-[#ff5500]
-                        ${commentSearch.isFiltering() ? "text-[#15fa34ff]" : ""}
+                        ${filtering ? "text-[#15fa34ff]" : ""}
                     `}
                 >
                     <FontAwesomeIcon icon={faSearch} />
                 </button>
-                {commentSearch.isFiltering()
+                {filtering
                     ? (
                         <button
                             onClick={() => {
                                 commentSearch.clear();
+                                dateFilter.clear();
                                 if (selectedRevision) {
                                     fetchComments(selectedRevision);
                                 }
@@ -55,8 +61,14 @@ export function useVideoCommentPanelDefinition(): VideoSidePanelDefinition {
         renderHeaderBody: () => (
             <SidebarGroup className="py-0">
                 <CalendarDateRadio
-                    value={commentSearch.dateRange}
-                    onSetValue={commentSearch.setDateRange}
+                    mode={dateFilter.mode}
+                    range={dateFilter.mode === "range" && dateFilter.from && dateFilter.to
+                        ? { from: new Date(dateFilter.from), to: new Date(dateFilter.to) }
+                        : undefined}
+                    onToday={dateFilter.setToday}
+                    onRecent={dateFilter.setRecent}
+                    onSetRange={dateFilter.setRange}
+                    onClear={dateFilter.clear}
                     className="size-10"
                 />
 

--- a/src/lib/utils/date-helper.ts
+++ b/src/lib/utils/date-helper.ts
@@ -1,5 +1,3 @@
-import { DateRange } from "react-day-picker";
-
 export const isInvalidDate = (date: Date | undefined) => date === undefined || Number.isNaN(date.getTime());
 
 export const toDateOnly = (d:Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
@@ -14,50 +12,3 @@ export const toDateRange = (from: Date | undefined, to: Date | undefined) => {
 
     return {from: start, to: end}
 }
-
-export const isSameDate = (l: Date, r: Date) => {
-    return l.getFullYear() === r.getFullYear()
-        && l.getMonth() === r.getMonth()
-        && l.getDate() === r.getDate();
-};
-
-export const isToday = (range?: DateRange) => {
-    if (!range?.from || !range.to) return false;
-
-    const from = toDateOnly(range.from);
-    const to = toDateOnly(range.to);
-    const today = toDateOnly(new Date());
-
-    return isSameDate(from, to) && isSameDate(from, today);
-};
-
-export const isRecent = (range?: DateRange, days = 3) => {
-    if (!range?.from || !range.to) return false;
-
-    const from = toDateOnly(range.from);
-    const to = toDateOnly(range.to);
-    const today = toDateOnly(new Date());
-
-    const expectedFrom = new Date(today);
-    expectedFrom.setDate(today.getDate() - days);
-
-    return isSameDate(to, today)
-        && isSameDate(from, expectedFrom);
-};
-
-/**
- * Revives DateRange restored from zustand persist.
- *
- * zustand persist serializes Date objects into strings via JSON,
- * so we need to convert them back to Date before using date APIs.
- */
-export const normalizePersistedDateRange = (
-    range?: DateRange,
-): DateRange | undefined => {
-    if (!range) return range;
-
-    return {
-        from: range.from ? new Date(range.from) : undefined,
-        to: range.to ? new Date(range.to) : undefined,
-    };
-};

--- a/src/stores/comment-search-store.ts
+++ b/src/stores/comment-search-store.ts
@@ -1,17 +1,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { DateRange } from "react-day-picker";
-import { normalizePersistedDateRange } from "@/lib/utils/date-helper";
 
 interface CommentSearchState {
-    dateRange: DateRange | undefined;
     hasDrawing: boolean;
     hasIssue: boolean;
     fetchAllComments: boolean;
     user: string | undefined;
     filterText: string;
 
-    setDateRange: (x: DateRange | undefined) => void;
     setHasDrawing: (x: boolean) => void;
     setHasIssue: (x: boolean) => void;
     setFetchAllComments: (x: boolean) => void;
@@ -22,7 +18,6 @@ interface CommentSearchState {
 }
 
 const InitCommentSearchState = {
-    dateRange: undefined,
     hasDrawing: false,
     hasIssue: false,
     fetchAllComments: true,
@@ -35,7 +30,6 @@ export const useCommentSearchStore = create<CommentSearchState>()(
         (set, get) => ({
             ...InitCommentSearchState,
 
-            setDateRange: (x: DateRange | undefined) => set({ dateRange: x }),
             setHasDrawing: (x: boolean) => set({ hasDrawing: x }),
             setHasIssue: (x: boolean) => set({ hasIssue: x }),
             setFetchAllComments: (x: boolean) => set({ fetchAllComments: x }),
@@ -53,10 +47,6 @@ export const useCommentSearchStore = create<CommentSearchState>()(
         }),
         {
             name: "comment-search-store",
-            onRehydrateStorage: () => (state) => {
-                if (!state) return;
-                state.dateRange = normalizePersistedDateRange(state.dateRange);
-            },
         },
     ),
 );

--- a/src/stores/comment-store.ts
+++ b/src/stores/comment-store.ts
@@ -5,6 +5,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useVideoStore } from "@/stores/video-store";
 import { useVideoReviewStore } from "@/stores/video-review-store";
 import { useCommentSearchStore } from "@/stores/comment-search-store";
+import { useCommentSearchDateFilterStore } from "@/stores/date-filter-store";
 
 interface CommentState {
     comments: VideoComment[];
@@ -40,7 +41,7 @@ export const useCommentStore = create<CommentState>((set, get) => ({
             videoId: videoRevision.videoId,
             selectRevision: videoRevision.revision,
             user: s.user,
-            dateRange: s.dateRange,
+            dateRange: useCommentSearchDateFilterStore.getState().resolve(),
             hasDrawing: s.hasDrawing,
             hasIssue: s.hasIssue,
             fetchAllComments: s.fetchAllComments,

--- a/src/stores/date-filter-store.ts
+++ b/src/stores/date-filter-store.ts
@@ -1,0 +1,87 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { DateRange } from "react-day-picker";
+import { toDateRange } from "@/lib/utils/date-helper";
+
+// Plain, JSON-serializable filter state. Relative modes ("today"/"recent") stay
+// relative so they follow the current day; "range" holds explicit epoch bounds
+// (numbers, so no Date persistence/revive is needed).
+export type DateFilterState = {
+    mode: "none" | "today" | "recent" | "range";
+    days?: number;
+    from?: number;
+    to?: number;
+};
+
+interface DateFilterStore extends DateFilterState {
+    setToday: () => void;
+    setRecent: (days?: number) => void;
+    setRange: (from: Date, to: Date) => void;
+    clear: () => void;
+    resolve: () => DateRange | undefined;
+}
+
+/**
+ * Revives persisted filter state.
+ *
+ * Only relative modes survive a reload/day-change; everything else collapses to
+ * "none". This drops stale absolute ranges AND legacy persisted `{from,to}`
+ * objects (written before this store existed) that carry no known mode.
+ */
+export function reviveDateFilter(persisted: unknown): DateFilterState {
+    if (persisted && typeof persisted === "object") {
+        const mode = (persisted as { mode?: unknown }).mode;
+        if (mode === "today") return { mode: "today" };
+        if (mode === "recent") {
+            const days = (persisted as { days?: unknown }).days;
+            return { mode: "recent", days: typeof days === "number" ? days : 3 };
+        }
+    }
+    return { mode: "none" };
+}
+
+/**
+ * Resolves filter state into concrete dates using the CURRENT date, so relative
+ * modes always reflect "now" instead of when the option was selected.
+ */
+export function resolveDateFilter(state: DateFilterState | undefined): DateRange | undefined {
+    if (!state || state.mode === "none") return undefined;
+
+    const now = new Date();
+    if (state.mode === "today") return toDateRange(now, now);
+    if (state.mode === "recent") {
+        const from = new Date(now);
+        from.setDate(now.getDate() - (state.days ?? 3));
+        return toDateRange(from, now);
+    }
+    return toDateRange(new Date(state.from!), new Date(state.to!));
+}
+
+// Factory: every date filter shares this logic but persists under a distinct key.
+export const createDateFilterStore = (name: string) =>
+    create<DateFilterStore>()(
+        persist(
+            (set, get) => ({
+                mode: "none",
+
+                setToday: () => set({ mode: "today", days: undefined, from: undefined, to: undefined }),
+                setRecent: (days = 3) => set({ mode: "recent", days, from: undefined, to: undefined }),
+                setRange: (from: Date, to: Date) =>
+                    set({ mode: "range", from: from.getTime(), to: to.getTime(), days: undefined }),
+                clear: () => set({ mode: "none", days: undefined, from: undefined, to: undefined }),
+                // Resolve the current filter to concrete dates so callers don't
+                // reach for the pure helper themselves.
+                resolve: () => resolveDateFilter(get()),
+            }),
+            {
+                name,
+                // Keep the live actions from currentState; overlay only the revived
+                // (relative-or-none) filter fields so no stale range is restored.
+                merge: (persisted, current) => ({ ...current, ...reviveDateFilter(persisted) }),
+            },
+        ),
+    );
+
+export const useVideoDateFilterStore = createDateFilterStore("video-date-filter");
+export const useVideoCommentsDateFilterStore = createDateFilterStore("video-comments-date-filter");
+export const useCommentSearchDateFilterStore = createDateFilterStore("comment-search-date-filter");

--- a/src/stores/video-search-store.ts
+++ b/src/stores/video-search-store.ts
@@ -1,11 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { DateRange } from "react-day-picker";
-import { normalizePersistedDateRange } from "@/lib/utils/date-helper";
 
 interface VideoSearchState {
-    videoDateRange: DateRange | undefined;
-    commentsDateRange: DateRange | undefined;
     hasComment: boolean;
     hasDrawing: boolean;
     hasIssue: boolean;
@@ -19,8 +15,6 @@ interface VideoSearchState {
     setHasIssue: (x: boolean) => void;
     setFilterIssue: (x: string) => void;
     setCommentUser: (x: string | undefined) => void;
-    setVideoDateRange: (x: DateRange | undefined) => void;
-    setCommentsDateRange: (x: DateRange | undefined) => void;
     setFilterTree: (x: string) => void;
     setTags: (x: string[]) => void;
     clear: () => void;
@@ -28,8 +22,6 @@ interface VideoSearchState {
 }
 
 const InitVideoSearchState = {
-    videoDateRange: undefined,
-    commentsDateRange: undefined,
     hasComment: false,
     hasDrawing: false,
     hasIssue: false,
@@ -49,8 +41,6 @@ export const useVideoSearchStore = create<VideoSearchState>()(
             setHasIssue: (x: boolean) => set({ hasIssue: x }),
             setFilterIssue: (x: string) => set({ filterIssue: x }),
             setCommentUser: (x: string | undefined) => set({ user: x }),
-            setVideoDateRange: (x: DateRange | undefined) => set({ videoDateRange: x }),
-            setCommentsDateRange: (x: DateRange | undefined) => set({ commentsDateRange: x }),
             setFilterTree: (x: string) => set({ filterTree: x }),
             setTags: (x: string[]) => set({ tags: x }),
             clear: () => set(InitVideoSearchState),
@@ -65,11 +55,6 @@ export const useVideoSearchStore = create<VideoSearchState>()(
         }),
         {
             name: "video-search-store",
-            onRehydrateStorage: () => (state) => {
-                if (!state) return;
-                state.videoDateRange = normalizePersistedDateRange(state.videoDateRange);
-                state.commentsDateRange = normalizePersistedDateRange(state.commentsDateRange);
-            },
         },
     ),
 );

--- a/src/stores/video-store.ts
+++ b/src/stores/video-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { Video, VideoRevision, VideoWithRevision } from "@/lib/db-types";
 import { useVideoSearchStore } from "@/stores/video-search-store";
+import { useVideoDateFilterStore, useVideoCommentsDateFilterStore } from "@/stores/date-filter-store";
 import * as api from '@/lib/fetch-wrapper';
 
 interface VideoState {
@@ -31,8 +32,8 @@ export const useVideoStore = create<VideoState>((set, get) => ({
         const s = useVideoSearchStore.getState();
         const data = await api.fetchVideos({
             user: s.user,
-            videoDateRange: s.videoDateRange,
-            commentsDateRange: s.commentsDateRange,
+            videoDateRange: useVideoDateFilterStore.getState().resolve(),
+            commentsDateRange: useVideoCommentsDateFilterStore.getState().resolve(),
             filterIssue: s.filterIssue,
             filterTree: s.filterTree,
             hasIssue: s.hasIssue,

--- a/tests/lib/date-filter.test.ts
+++ b/tests/lib/date-filter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { toDateRange } from "@/lib/utils/date-helper";
+import { createDateFilterStore, resolveDateFilter, reviveDateFilter } from "@/stores/date-filter-store";
+
+// Expected values are derived from a fresh `new Date()` so the assertions stay
+// date-independent and mirror the resolver's own "current date" behavior.
+describe("resolveDateFilter", () => {
+    it("returns undefined for none / undefined", () => {
+        expect(resolveDateFilter({ mode: "none" })).toBeUndefined();
+        expect(resolveDateFilter(undefined)).toBeUndefined();
+    });
+
+    it("resolves today to the start/end of the current day", () => {
+        const now = new Date();
+        const range = resolveDateFilter({ mode: "today" });
+
+        const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        start.setHours(0, 0, 0, 0);
+        const end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        end.setHours(23, 59, 59, 999);
+
+        expect(range?.from?.getTime()).toBe(start.getTime());
+        expect(range?.to?.getTime()).toBe(end.getTime());
+    });
+
+    it("resolves recent to start of (today - days) through end of today", () => {
+        const now = new Date();
+        const range = resolveDateFilter({ mode: "recent", days: 3 });
+
+        const from = new Date(now);
+        from.setDate(now.getDate() - 3);
+        const expectedFrom = new Date(from.getFullYear(), from.getMonth(), from.getDate());
+        expectedFrom.setHours(0, 0, 0, 0);
+        const expectedTo = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        expectedTo.setHours(23, 59, 59, 999);
+
+        expect(range?.from?.getTime()).toBe(expectedFrom.getTime());
+        expect(range?.to?.getTime()).toBe(expectedTo.getTime());
+    });
+
+    it("resolves an explicit range from its epoch bounds via toDateRange", () => {
+        const from = new Date(2026, 0, 10, 8, 30);
+        const to = new Date(2026, 0, 15, 20, 45);
+        const range = resolveDateFilter({ mode: "range", from: from.getTime(), to: to.getTime() });
+        const expected = toDateRange(from, to);
+
+        expect(range?.from?.getTime()).toBe(expected.from?.getTime());
+        expect(range?.to?.getTime()).toBe(expected.to?.getTime());
+    });
+});
+
+describe("reviveDateFilter", () => {
+    it("keeps today", () => {
+        expect(reviveDateFilter({ mode: "today" })).toEqual({ mode: "today" });
+    });
+
+    it("keeps recent with its days, defaulting to 3", () => {
+        expect(reviveDateFilter({ mode: "recent", days: 7 })).toEqual({ mode: "recent", days: 7 });
+        expect(reviveDateFilter({ mode: "recent" })).toEqual({ mode: "recent", days: 3 });
+    });
+
+    it("collapses an explicit range to none so no stale range is restored", () => {
+        expect(reviveDateFilter({ mode: "range", from: 1, to: 2 })).toEqual({ mode: "none" });
+    });
+
+    it("collapses the legacy no-mode {from,to} shape to none", () => {
+        const legacy = { from: "2026-01-10T00:00:00.000Z", to: "2026-01-12T00:00:00.000Z" };
+        expect(reviveDateFilter(legacy)).toEqual({ mode: "none" });
+    });
+
+    it("collapses unexpected/garbage input to none", () => {
+        expect(reviveDateFilter(undefined)).toEqual({ mode: "none" });
+        expect(reviveDateFilter(null)).toEqual({ mode: "none" });
+        expect(reviveDateFilter("nonsense")).toEqual({ mode: "none" });
+        expect(reviveDateFilter(42)).toEqual({ mode: "none" });
+        expect(reviveDateFilter({ mode: "weird" })).toEqual({ mode: "none" });
+    });
+});
+
+describe("store resolve() method", () => {
+    it("wires the store state through the resolver", () => {
+        const useStore = createDateFilterStore("test");
+
+        useStore.getState().setToday();
+        const range = useStore.getState().resolve();
+
+        const now = new Date();
+        const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        start.setHours(0, 0, 0, 0);
+        const end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        end.setHours(23, 59, 59, 999);
+
+        expect(range?.from?.getTime()).toBe(start.getTime());
+        expect(range?.to?.getTime()).toBe(end.getTime());
+
+        useStore.getState().clear();
+        expect(useStore.getState().resolve()).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes the shooting-date filter drifting after the day changes (issue #83).

- store the filter as a per-filter Zustand store (mode + epoch numbers) instead of persisting resolved absolute dates
- resolve today/recent to concrete dates at query time so they follow the current day
- reset the calendar range and any legacy persisted value on rehydrate (no stale/invalid dates)
- expose resolve() on each store so consumers read the range without a separate helper

Closes #83